### PR TITLE
Update gchat_endpoint zbx_google_chat_mediatype.yaml

### DIFF
--- a/zbx_google_chat_mediatype.yaml
+++ b/zbx_google_chat_mediatype.yaml
@@ -68,7 +68,7 @@ zabbix_export:
           value: '{EVENT.VALUE}'
         -
           name: gchat_endpoint
-          value: ''
+          value: '{ALERT.SENDTO}'
         -
           name: host_ip
           value: '{HOST.IP}'


### PR DESCRIPTION
I am using several Google Chat groups, for each of them I create a user with a Media type of "Google Chat" and a value of Web Hook. This way I can send to different groups using one Media type.