### PR TITLE
Rename SetProxy to setProxy.

### DIFF
--- a/zbx_google_chat_mediatype.yaml
+++ b/zbx_google_chat_mediatype.yaml
@@ -297,7 +297,7 @@ zabbix_export:
             request.addHeader('Content-Type: application/json');
         
             if (typeof params.HTTPProxy === 'string' && params.HTTPProxy !== '') {
-                request.SetProxy(params.HTTPProxy);
+                request.setProxy(params.HTTPProxy);
             }
         
             Zabbix.Log(4, '[ Google Chat Webhook ] JSON: ' + JSON.stringify(body));


### PR DESCRIPTION
This change is necessary for Zabbix > 6.0. This was tested successfully on Zabbix 7.0.6.

Zabbix 5.4 renamed a bunch of methods "in order to make them JavaScript alike".

"Older methods should be marked as deprecated and supported till Zabbix 6.0 (included)." https://support.zabbix.com/browse/ZBXNEXT-6241

https://www.zabbix.com/documentation/5.4/en/manual/introduction/whatsnew540#naming_in_javascript_objects

https://git.zabbix.com/projects/ZBX/repos/zabbix/commits/67c4a4b3b0c9a5a99de56d7b0349d50c2783520a#src/libs/zbxembed/httprequest.c